### PR TITLE
Add data card endpoint

### DIFF
--- a/api/routers/annotation.py
+++ b/api/routers/annotation.py
@@ -69,7 +69,7 @@ async def link_dataset_columns_to_dkg_info(gpt_key: str, csv_file: UploadFile = 
 
     doc = await doc_file.read()
     doc = doc.decode()
-    s, success = dataset_header_document_dkg(header=csv_str, doc=doc, gpt_key=gpt_key)
+    s, success = await dataset_header_document_dkg(header=csv_str, doc=doc, gpt_key=gpt_key)
 
     if not success:
         return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=s)
@@ -86,7 +86,6 @@ async def link_dataset_columns_to_dkg_info(gpt_key: str, csv_file: UploadFile = 
 #     return ast.literal_eval(s)
 
 
-dataset_header_document_dkg
 @router.post("/upload_file_extract/", tags=["Paper-2-annotated-vars"])
 async def upload_file_annotate(gpt_key: str, file: UploadFile = File(...)):
     """

--- a/api/routers/annotation.py
+++ b/api/routers/annotation.py
@@ -10,7 +10,7 @@ sys.path.append(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 )
 from src.text_search import text_var_search, vars_to_json, vars_dedup
-from src.connect import vars_formula_connection, dataset_header_document_dkg, vars_dataset_connection_simplified
+from src.connect import vars_formula_connection, dataset_header_document_dkg, vars_dataset_connection_simplified, construct_data_card
 from src.link_annos_to_pyacset import link_annos_to_pyacset
 
 router = APIRouter()
@@ -73,6 +73,31 @@ async def link_dataset_columns_to_dkg_info(gpt_key: str, csv_file: UploadFile = 
 
     if not success:
         return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=s)
+
+    return ast.literal_eval(s)
+
+
+@router.post("/get_data_card", tags=["Paper-2-annotated-vars"])
+async def get_data_card(gpt_key: str, csv_file: UploadFile = File(...), doc_file: UploadFile = File(...)):
+
+    csv_string = await csv_file.read()
+    csv_string = csv_string.decode()
+    csv_strings = csv_string.split('\n')
+
+    if len(csv_strings) == 0:
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Empty CSV file")
+
+    # get header and <=5 random rows
+    num_rows_to_sample = min(5, len(csv_strings) - 1)
+    csv_str = csv_strings[0] + '\n' + '\n'.join(random.sample(csv_strings[1:], num_rows_to_sample))
+
+    doc = await doc_file.read()
+    doc = doc.decode()
+
+    s, success = construct_data_card(data=csv_str, data_doc=doc, gpt_key=gpt_key)
+
+    if not success:
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=s)
 
     return ast.literal_eval(s)
 

--- a/api/routers/annotation.py
+++ b/api/routers/annotation.py
@@ -10,7 +10,7 @@ sys.path.append(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 )
 from src.text_search import text_var_search, vars_to_json, vars_dedup
-from src.connect import vars_formula_connection, dataset_header_document_dkg, vars_dataset_connection_simplified, construct_data_card
+from src.connect import vars_formula_connection, dataset_header_document_dkg, vars_dataset_connection_simplified
 from src.link_annos_to_pyacset import link_annos_to_pyacset
 
 router = APIRouter()
@@ -73,31 +73,6 @@ async def link_dataset_columns_to_dkg_info(gpt_key: str, csv_file: UploadFile = 
 
     if not success:
         return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=s)
-
-    return ast.literal_eval(s)
-
-
-@router.post("/get_data_card", tags=["Paper-2-annotated-vars"])
-async def get_data_card(gpt_key: str, csv_file: UploadFile = File(...), doc_file: UploadFile = File(...)):
-
-    csv_string = await csv_file.read()
-    csv_string = csv_string.decode()
-    csv_strings = csv_string.split('\n')
-
-    if len(csv_strings) == 0:
-        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Empty CSV file")
-
-    # get header and <=5 random rows
-    num_rows_to_sample = min(5, len(csv_strings) - 1)
-    csv_str = csv_strings[0] + '\n' + '\n'.join(random.sample(csv_strings[1:], num_rows_to_sample))
-
-    doc = await doc_file.read()
-    doc = doc.decode()
-
-    s, success = construct_data_card(data=csv_str, data_doc=doc, gpt_key=gpt_key)
-
-    if not success:
-        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=s)
 
     return ast.literal_eval(s)
 

--- a/api/routers/cards.py
+++ b/api/routers/cards.py
@@ -1,0 +1,35 @@
+import ast, io, random, sys, os
+
+from fastapi import APIRouter, status, UploadFile, File
+from fastapi.responses import JSONResponse
+
+sys.path.append(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from src.connect import construct_data_card
+
+router = APIRouter()
+
+@router.post("/get_data_card", tags=["Data-and-model-cards"])
+async def get_data_card(gpt_key: str, csv_file: UploadFile = File(...), doc_file: UploadFile = File(...)):
+
+    csv_string = await csv_file.read()
+    csv_string = csv_string.decode()
+    csv_strings = csv_string.split('\n')
+
+    if len(csv_strings) == 0:
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Empty CSV file")
+
+    # get header and <=5 random rows
+    num_rows_to_sample = min(5, len(csv_strings) - 1)
+    csv_str = csv_strings[0] + '\n' + '\n'.join(random.sample(csv_strings[1:], num_rows_to_sample))
+
+    doc = await doc_file.read()
+    doc = doc.decode()
+
+    s, success = construct_data_card(data=csv_str, data_doc=doc, gpt_key=gpt_key)
+
+    if not success:
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=s)
+
+    return ast.literal_eval(s)

--- a/api/routers/cards.py
+++ b/api/routers/cards.py
@@ -1,4 +1,5 @@
 import ast, io, random, sys, os
+import asyncio
 
 from fastapi import APIRouter, status, UploadFile, File
 from fastapi.responses import JSONResponse
@@ -6,30 +7,38 @@ from fastapi.responses import JSONResponse
 sys.path.append(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 )
-from src.connect import construct_data_card
+from src.connect import construct_data_card, dataset_header_document_dkg
 
 router = APIRouter()
 
 @router.post("/get_data_card", tags=["Data-and-model-cards"])
 async def get_data_card(gpt_key: str, csv_file: UploadFile = File(...), doc_file: UploadFile = File(...)):
 
-    csv_string = await csv_file.read()
-    csv_string = csv_string.decode()
-    csv_strings = csv_string.split('\n')
+    files = [csv_file.read(), doc_file.read()]
+    csv, doc = await asyncio.gather(*files)
 
+    # process CSV; get header and <= 5 random rows
+    csv_string = csv.decode()
+    csv_strings = csv_string.split('\n')
     if len(csv_strings) == 0:
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Empty CSV file")
-
-    # get header and <=5 random rows
     num_rows_to_sample = min(5, len(csv_strings) - 1)
     csv_str = csv_strings[0] + '\n' + '\n'.join(random.sample(csv_strings[1:], num_rows_to_sample))
 
-    doc = await doc_file.read()
+    # process doc
+    # TODO: handle docs that are too long to fit in the context window
     doc = doc.decode()
 
-    s, success = construct_data_card(data=csv_str, data_doc=doc, gpt_key=gpt_key)
+    calls = [construct_data_card(data=csv_str, data_doc=doc, gpt_key=gpt_key), dataset_header_document_dkg(header=csv_str, doc=doc, gpt_key=gpt_key)]
+    results = await asyncio.gather(*calls)
+    for s, success in results:
+        if not success:
+            return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=s)
 
-    if not success:
-        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=s)
+    data_card = ast.literal_eval(results[0][0])
+    data_profiling = ast.literal_eval(results[1][0])
+    if 'DATA_PROFILING_RESULT' in data_card:
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content='DATA_PROFILING_RESULT cannot be a requested field in the data card.')
+    data_card['DATA_PROFILING_RESULT'] = data_profiling
 
-    return ast.literal_eval(s)
+    return data_card

--- a/api/server.py
+++ b/api/server.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 
 from file_cache import init_cache_directory
-from routers import code_dataset, code_formula, code_text, avail_check, petri, annotation, integration
+from routers import code_dataset, code_formula, code_text, avail_check, petri, annotation, integration, cards
 
 tags_metadata = [
     # {
@@ -25,7 +25,11 @@ tags_metadata = [
     {
         "name": "TA1-Integration",
         "description": "Integate Arizona's output with the MIT extraction pipeline."
-    }
+    },
+    {
+        "name": "Data-and-model-cards",
+        "description": "Requests related to generating data and model cards.",
+    },
 ]
 
 
@@ -65,5 +69,6 @@ app = build_api()
 app.include_router(petri.router, prefix="/petri")
 app.include_router(annotation.router, prefix="/annotation")
 app.include_router(integration.router, prefix="/integration")
+app.include_router(cards.router, prefix="/cards")
 
 

--- a/src/connect.py
+++ b/src/connect.py
@@ -379,7 +379,7 @@ def dataset_header_dkg(header, gpt_key=''):
     return json.dumps(col_ant), True
 
 
-def dataset_header_document_dkg(header, doc,  gpt_key=''):
+async def dataset_header_document_dkg(header, doc,  gpt_key=''):
     """
     Grounding the column header to DKG terms
     :param header: Dataset header string seperated with comma
@@ -431,7 +431,7 @@ def dataset_header_document_dkg(header, doc,  gpt_key=''):
     return json.dumps(col_ant), True
 
 
-def construct_data_card(data, data_doc,  gpt_key='', fields=None, model="gpt-3.5-turbo"):
+async def construct_data_card(data, data_doc,  gpt_key='', fields=None, model="gpt-3.5-turbo"):
     """
     Constructing a data card for a given dataset and its description.
     :param data: Small dataset, including header and optionally a few rows

--- a/src/connect.py
+++ b/src/connect.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import OrderedDict
 import io
 import json
 import os
@@ -221,6 +222,16 @@ def get_csv_doc_prompt(csv, doc):
     # print(prompt)
     return prompt
 
+def get_data_card_prompt(fields, csv, doc):
+    with open(os.path.join(os.path.dirname(__file__), "prompts/data_card_prompt.txt"), "r") as text_file:
+        prompt = text_file.read()
+
+    fields_str = '\n'.join([f"{f[0]}: {f[1]}" for f in fields])
+    prompt = prompt.replace("[FIELDS]", fields_str)
+    prompt = prompt.replace("[CSV]", csv)
+    prompt = prompt.replace("[DOC]", doc)
+    return prompt
+
 def get_text_column_prompt(text, column):
     text_file = open(os.path.join(os.path.dirname(__file__), "prompts/text_column_prompt.txt"), "r")
     prompt = text_file.read()
@@ -420,6 +431,49 @@ def dataset_header_document_dkg(header, doc,  gpt_key=''):
     return json.dumps(col_ant), True
 
 
+def construct_data_card(data, data_doc,  gpt_key='', fields=None, model="gpt-3.5-turbo"):
+    """
+    Constructing a data card for a given dataset and its description.
+    :param data: Small dataset, including header and optionally a few rows
+    :param data_doc: Document string
+    :param gpt_key: OpenAI API key
+    :param fields: Fields to be filled in the data card
+    :param model: OpenAI model to use
+    :return: Data card
+    """
+
+    if fields is None:
+        fields = [("DESCRIPTION",  "Short description of the dataset (1-3 sentences)."),
+                  ("AUTHOR_NAME",  "Name of publishing institution or author."),
+                  ("AUTHOR_EMAIL", "Email address for the author of this dataset."),
+                  ("DATE",         "Date of publication of this dataset."),
+                  ("SCHEMA",       "Schema of the data in this dataset."),
+                  ("PROVENANCE",   "Short (1 sentence) description of how the data was collected."),
+                  ("SENSITIVITY",  "Is there any human-identifying information in the dataset?"),
+                  ("EXAMPLES",     "One example data point from the dataset, formatted as a JSON object."),
+                  ("LICENSE",      "License for this dataset."),
+        ]
+
+    prompt = get_data_card_prompt(fields, data, data_doc)
+    match = get_gpt4_match(prompt, gpt_key, model=model)
+    print(match)
+
+    results = OrderedDict([(f[0], "UNKNOWN") for f in fields])
+    for res in match.split("\n"):
+        if res == "":
+            continue
+        res = res.split(":", 1)
+        if len(res) != 2:
+            continue
+        field, value = res
+        field = field.strip()
+        value = value.strip()
+        for f in fields:
+            if f[0] == field:
+                results[field] = value
+                break
+
+    return json.dumps(results), True
 
 
 def select_text(lines, s, t, buffer, interactive=True):

--- a/src/prompts/data_card_prompt.txt
+++ b/src/prompts/data_card_prompt.txt
@@ -1,0 +1,28 @@
+I have a dataset (as a CSV file) as well as a textual description of the contents of the dataset.
+I need to extract some metadata from the dataset and the textual description.
+
+The metadata to be extracted is as follows:
+```txt
+[FIELDS]
+```
+
+The dataset is as follows:
+```csv
+[CSV]
+```
+
+The textual description is as follows:
+```txt
+[DOC]
+```
+
+Please help me extract the metadata from the dataset and the textual description.
+Print the result in the following format:
+```txt
+<field name>: <field value>
+<field name>: <field value>
+<field name>: <field value>
+...
+```
+Do not hallucinate metadata; only print metadata that can be extracted from the dataset and the textual description.
+If the metadata cannot be extracted, please print "UNKNOWN" instead of the field value.


### PR DESCRIPTION
As requested by Mike.

This basically calls GPT-x (currently `gpt-3.5-turbo`) and asks it to extract a certain list of fields from the dataset and its documentation.
Currently, this assumes that you have access to the document description.
We might want to add support for scenarios in which you only have access to the CSV.

Values that cannot be extracted are set to "UNKNOWN". (Should it be None or "null" instead?)