### PR TITLE
remove redundancy in call to openai

### DIFF
--- a/demos/2023-07/test_scenarios.py
+++ b/demos/2023-07/test_scenarios.py
@@ -5,10 +5,10 @@ from fastapi.testclient import TestClient
 
 
 test_papers = [
-#    '../../resources/models/Bucky/bucky.txt',
-    './text_ijerph-18-09027.txt',
-    './text_s41598-022-06159-x.txt',
-    'text_shakari-wastewater.txt',
+        '../../resources/models/Bucky/bucky.txt',
+    # './text_ijerph-18-09027.txt',
+    # './text_s41598-022-06159-x.txt',
+    # 'text_shakari-wastewater.txt',
 ]
 
 def run_test(paper_path):

--- a/demos/2023-07/time-after.py
+++ b/demos/2023-07/time-after.py
@@ -1,0 +1,16 @@
+# import sys
+# srcpath = '/Users/orm/repos/mitaskem/src'
+# askempath = '/Users/orm/repos/mitaskem'
+# sys.path.append(askempath)
+# sys.path.append(srcpath)
+
+import os
+import openai
+from mit_extraction import async_mit_extraction_restAPI
+import asyncio
+
+bucky_path = os.path.abspath('../resources/models/Bucky/bucky.txt')
+res = asyncio.run(async_mit_extraction_restAPI('/tmp/askemcache/bucky.txt', gpt_key=openai.api_key, cache_dir='/tmp/askemcache/'))
+
+print('result:', res)
+

--- a/src/mira_dkg_interface.py
+++ b/src/mira_dkg_interface.py
@@ -1,16 +1,51 @@
 import requests
-
+import aiohttp
+import asyncio
+import json
 
 MIRA_DKG_URL = 'http://34.230.33.149:8771'
 
 
+async def aget_mira_dkg_term(session, term,  attribs, fallback, limit):
+    json_params = json.dumps({'q': term, 'wikidata_fallback': fallback, 'limit': limit})
+
+    async with session.get(MIRA_DKG_URL + '/api/search', params=json_params) as response:
+        if not response.ok:
+            return [[]]
+        else:
+            async with response.json() as rjson:
+                return  [[t[attrib] for attrib in attribs if t[attrib] is not None] for t in rjson]
+
+
 def get_mira_dkg_term(term, attribs, fallback=False, limit=5):
-    res = requests.get(MIRA_DKG_URL + '/api/search', params={'q': term, 'wikidata_fallback': fallback, 'limit': limit})
+    params = {'q': term, 'wikidata_fallback': fallback, 'limit': limit}
+    res = requests.get(MIRA_DKG_URL + '/api/search', params=params)
     # handle dkg error
     if not res.ok:
         return [[]]
     res = [[t[attrib] for attrib in attribs if t[attrib] is not None] for t in res.json()]
+    return res          
+
+def batch_get_mira_dkg_term(terms, attribs, fallback=False, limit=5):
+    res = []
+    for term in terms:
+        res.append(get_mira_dkg_term(term, attribs, fallback, limit))
     return res
+
+async def abatch_get_mira_dkg_term(terms, attribs, fallback=False, limit=5):
+    tasks = []
+    async with aiohttp.ClientSession() as session:
+        for term in terms:
+            cor = aget_mira_dkg_term(session,term, attribs, fallback, limit)
+            tasks.append(asyncio.create_task(cor))
+
+
+        ans = []
+        for task in tasks:
+            ans.append(await task)
+
+    return ans
+
 
 def build_local_ontology(terms, attribs):
     local_ontology = {

--- a/src/mit_extraction.py
+++ b/src/mit_extraction.py
@@ -160,19 +160,24 @@ async def async_mit_extraction_restAPI(file_name, gpt_key, cache_dir="/tmp/askem
     paper_name = file_name.split(".txt")[0]
     org_file = os.path.join(cache_dir, file_name)
     print("is file existing", os.path.exists(org_file))
-    extract_vars(org_file, cache_dir)
-    file_path = os.path.join(cache_dir, paper_name+"_vars.txt")
-    print(file_path)
+    # extract_vars(org_file, cache_dir) # this calls open ai api.
+    # file_path = os.path.join(cache_dir, paper_name+"_vars.txt")
+    # print(file_path)
+
+
+    file_path = file_name
     with open(file_path, "r") as f:
         text = f.read()
         json_str = await afind_vars_from_text(text, gpt_key)
-        print(type(json_str))
+        # print(type(json_str))
+    # dkg_json = json.loads(json.dumps(json_str))
 
     dkg_json = json.loads(json.dumps(json_str))
     for variable in dkg_json:
         variable["title"] = paper_name
     dkg_json_string = json.dumps(dkg_json)
-    print(dkg_json_string)
+
+    # print(dkg_json_string) 
     dirname = os.path.dirname(__file__)
     dir = os.path.join(dirname, '../resources/dataset/ensemble')
     # dir = "../resources/dataset/ensemble/"
@@ -184,7 +189,7 @@ async def async_mit_extraction_restAPI(file_name, gpt_key, cache_dir="/tmp/askem
 
     with open(os.path.join(dir, "headers.txt")) as f:
         dataset_str = f.read()
-        print(dataset_str[:419])
+ #       print(dataset_str[:419])
 
 
     json_str, success = vars_dataset_connection_simplified(dkg_json_string, dataset_str, gpt_key)

--- a/src/mit_extraction.py
+++ b/src/mit_extraction.py
@@ -9,7 +9,7 @@ from connect import get_mit_arizona_var_prompt, get_gpt4_match, vars_dataset_con
 from dataset_id import modify_dataset
 from ensemble.ensemble import load_paper_info, extract_variables, extract_vars
 from gpt_key import *
-from text_search import text_var_search, vars_dedup, vars_to_json
+from text_search import text_var_search, vars_dedup, vars_to_json, avars_to_json
 
 PARAM = "/Users/chunwei/research/mitaskem/resources/xDD/params/"
 API_ROOT = "http://0.0.0.0:8000/"
@@ -159,7 +159,7 @@ async def afind_vars_from_text(text: str, gpt_key: str):
     openai_done = time.time()
     print(f'{openai_done - start = }')
     
-    tmp2 = vars_to_json(res)
+    tmp2 = await avars_to_json(res)
     mira_done = time.time()
     print(f'{mira_done - openai_done = }')
     return ast.literal_eval(tmp2)

--- a/src/mit_extraction.py
+++ b/src/mit_extraction.py
@@ -147,16 +147,27 @@ async def _extract_text_vars(text, var_prompt):
     tmp1 = vars_dedup(unified)
     return tmp1
 
+import time
+
+#@profile
 async def afind_vars_from_text(text: str, gpt_key: str):
     with open(os.path.join(os.path.dirname(__file__), 'prompts/text_var_prompt.txt'), "r") as f:
         var_prompt = f.read()
     
+    start = time.time()
     res = await _extract_text_vars(text, var_prompt)
+    openai_done = time.time()
+    print(f'{openai_done - start = }')
     
     tmp2 = vars_to_json(res)
+    mira_done = time.time()
+    print(f'{mira_done - openai_done = }')
     return ast.literal_eval(tmp2)
+import time
 
+#@profile
 async def async_mit_extraction_restAPI(file_name, gpt_key, cache_dir="/tmp/askem"):
+    start = time.time()
     paper_name = file_name.split(".txt")[0]
     org_file = os.path.join(cache_dir, file_name)
     print("is file existing", os.path.exists(org_file))
@@ -166,13 +177,17 @@ async def async_mit_extraction_restAPI(file_name, gpt_key, cache_dir="/tmp/askem
 
 
     file_path = file_name
+    t2 = time.time()
+    print(f'{t2 - start=}')
     with open(file_path, "r") as f:
         text = f.read()
         json_str = await afind_vars_from_text(text, gpt_key)
         # print(type(json_str))
     # dkg_json = json.loads(json.dumps(json_str))
 
-    dkg_json = json.loads(json.dumps(json_str))
+    t3 = time.time()
+    print(f'{t3- t2=}')
+    dkg_json = json_str
     for variable in dkg_json:
         variable["title"] = paper_name
     dkg_json_string = json.dumps(dkg_json)
@@ -193,7 +208,9 @@ async def async_mit_extraction_restAPI(file_name, gpt_key, cache_dir="/tmp/askem
 
 
     json_str, success = vars_dataset_connection_simplified(dkg_json_string, dataset_str, gpt_key)
-    print(json_str)
+    t4 = time.time()
+    print(f'{t4-t3=}')
+    #  print(json_str)
 
     data_json = json.loads(json_str)
 

--- a/src/text_search.py
+++ b/src/text_search.py
@@ -54,9 +54,41 @@ def vars_to_json(var_dict: dict) -> str:
     is_first = True
     id = 0
 
-    for var_name in var_dict:
+    batch_var_ground = batch_get_mira_dkg_term(var_dict.keys(), ['id', 'name'])
+
+    for var_name, var_ground in zip(var_dict, batch_var_ground):
         var_defs_s = "[\"" + '\",\"'.join(i for i in var_dict[var_name][:MAX_TEXT_MATCHES]) + "\"]"
-        var_ground = get_mira_dkg_term(var_name, ['id', 'name'])[:MAX_DKG_MATCHES]
+        #var_ground = get_mira_dkg_term(var_name, ['id', 'name'])
+        var_ground = var_ground[:MAX_DKG_MATCHES]
+        var_ground_s = "[" + ",".join([("[\"" + "\",\"".join([str(item) for item in sublist]) + "\"]") for sublist in var_ground]) + "]"
+
+        if is_first:
+            is_first = False
+        else:
+            s_out += ","
+
+        s_out += "{\"type\" : \"variable\", \"name\": \"" + var_name \
+        + "\", \"id\" : \"v" + str(id) + "\", \"text_annotations\": " + var_defs_s \
+        + ", \"dkg_annotations\" : " + var_ground_s + "}"
+
+        id += 1
+    
+    s_out += "]"
+
+    return s_out
+
+async def avars_to_json(var_dict: dict) -> str:
+
+    s_out = "["
+    is_first = True
+    id = 0
+
+    batch_var_ground = await abatch_get_mira_dkg_term(var_dict.keys(), ['id', 'name'])
+
+    for var_name, var_ground in zip(var_dict, batch_var_ground):
+        var_defs_s = "[\"" + '\",\"'.join(i for i in var_dict[var_name][:MAX_TEXT_MATCHES]) + "\"]"
+        #var_ground = get_mira_dkg_term(var_name, ['id', 'name'])
+        var_ground = var_ground[:MAX_DKG_MATCHES]
         var_ground_s = "[" + ",".join([("[\"" + "\",\"".join([str(item) for item in sublist]) + "\"]") for sublist in var_ground]) + "]"
 
         if is_first:


### PR DESCRIPTION
for whatever reason, extract_vars calls open ai api to extract vars. then saves it to local file _vars.txt
It also has params.txt but doesnt use that.
then two lines later a different function loads that file and calls open ai api to extract vars from that file. 

just replace it with one call to openai. 