### PR TITLE
Fix batched async MIRA lookups

### DIFF
--- a/src/mira_dkg_interface.py
+++ b/src/mira_dkg_interface.py
@@ -1,21 +1,22 @@
 import requests
 import aiohttp
 import asyncio
-import json
 
 MIRA_DKG_URL = 'http://34.230.33.149:8771'
 
 
-async def aget_mira_dkg_term(session, term,  attribs, fallback, limit):
-    json_params = json.dumps({'q': term, 'wikidata_fallback': fallback, 'limit': limit})
+async def aget_mira_dkg_term(session, term: str,  attribs, fallback: bool, limit: int):
+    fallback = str(fallback).lower()
+    params = {'q': term, 'wikidata_fallback': fallback, 'limit': limit}
 
-    async with session.get(MIRA_DKG_URL + '/api/search', params=json_params) as response:
+    async with session.get(MIRA_DKG_URL + '/api/search', params=params) as response:
         if not response.ok:
+            print(f"aget_mira_dkg_term got response.ok==False for term {term}. Response: {response}")
             return [[]]
         else:
-            async with response.json() as rjson:
-                return  [[t[attrib] for attrib in attribs if t[attrib] is not None] for t in rjson]
-
+            rjson = await response.json()  # TODO does this __need__ to be awaited?
+            print(f"aget_mira_dkg_term got response.json() for term {term}. Response: {rjson}")
+            return [[t[attrib] for attrib in attribs if t[attrib] is not None] for t in rjson]
 
 def get_mira_dkg_term(term, attribs, fallback=False, limit=5):
     params = {'q': term, 'wikidata_fallback': fallback, 'limit': limit}
@@ -33,6 +34,7 @@ def batch_get_mira_dkg_term(terms, attribs, fallback=False, limit=5):
     return res
 
 async def abatch_get_mira_dkg_term(terms, attribs, fallback=False, limit=5):
+    print(f"abatch_get_mira_dkg_term: {terms}")
     tasks = []
     async with aiohttp.ClientSession() as session:
         for term in terms:


### PR DESCRIPTION
fixes:
- pass params as dict, not json, so the URL is populated correctly
- await response json (this doesn't seem to error before? I don't really know what's going on here)

Performance regression tests:
- Running on `Bucky` took ~1 minute for me. More than the ~25s Oscar reported this morning, less than the ~2 minutes he reported it took before.
- Running on `text_ijerph-18-09027.txt` took 40s. It took roughly 4 minutes when I ran it this morning.
- Running on `text_s41598-022-06159-x.txt` took 1m40s. It took 3m20s last time I ran it.

@orm011 If you still have your profiling scripts, maybe we could profile this branch quickly before merging to make sure we're still getting the same speedups on average?