### PR TITLE
Alternative code paths for non-tabular data

### DIFF
--- a/api/routers/annotation.py
+++ b/api/routers/annotation.py
@@ -11,7 +11,7 @@ sys.path.append(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 )
 from src.text_search import text_var_search, vars_to_json, vars_dedup
-from src.connect import vars_formula_connection, dataset_header_document_dkg, vars_dataset_connection_simplified
+from src.connect import vars_formula_connection, dataset_header_document_dkg, vars_dataset_connection_simplified, matrix_dkg, get_dataset_type
 from src.link_annos_to_pyacset import link_annos_to_pyacset
 
 router = APIRouter()
@@ -61,6 +61,29 @@ def link_annotation_to_pyacset_and_paper_info(pyacset_str: str, annotations_str:
     return ast.literal_eval(s)
 
 
+@router.post("/profile_matrix_data", tags=["Paper-2-annotated-vars"])
+async def link_dataset_columns_to_dkg_info(gpt_key: str, csv_file: UploadFile = File(...),
+                                           doc_file: UploadFile = File(...), smart: Optional[bool] = False):
+    """
+           Smart run provides better results but may result in slow response times as a consequence of extra GPT calls.
+    """
+    csv_string = await csv_file.read()
+    csv_str = csv_string.decode()
+
+    doc = await doc_file.read()
+    doc = doc.decode()
+
+    dataset_type = get_dataset_type(csv_str)
+    if dataset_type != 'matrix':
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Invalid CSV file; data type does not seem to be a matrix.")
+
+    s, success = await matrix_dkg(data=csv_str, doc=doc, dataset_name=csv_file.filename, doc_name=doc_file.filename, gpt_key=gpt_key, smart=smart)
+
+    if not success:
+        return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=s)
+
+    return ast.literal_eval(s)
+
 @router.post("/link_dataset_col_to_dkg", tags=["Paper-2-annotated-vars"])
 async def link_dataset_columns_to_dkg_info(gpt_key: str, csv_file: UploadFile = File(...),
                                            doc_file: UploadFile = File(...), smart: Optional[bool] = False):
@@ -72,6 +95,10 @@ async def link_dataset_columns_to_dkg_info(gpt_key: str, csv_file: UploadFile = 
 
     doc = await doc_file.read()
     doc = doc.decode()
+
+    dataset_type = get_dataset_type(csv_str)
+    if dataset_type == 'matrix':
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Invalid CSV file; seems to be a matrix, not tabular.")
 
     s, success = await dataset_header_document_dkg(data=csv_str, doc=doc, dataset_name=csv_file.filename, doc_name=doc_file.filename, gpt_key=gpt_key, smart=smart)
 

--- a/api/routers/annotation.py
+++ b/api/routers/annotation.py
@@ -11,7 +11,7 @@ sys.path.append(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 )
 from src.text_search import text_var_search, vars_to_json, vars_dedup
-from src.connect import vars_formula_connection, dataset_header_document_dkg, vars_dataset_connection_simplified, matrix_dkg, get_dataset_type
+from src.connect import vars_formula_connection, dataset_header_document_dkg, vars_dataset_connection_simplified, profile_matrix, get_dataset_type
 from src.link_annos_to_pyacset import link_annos_to_pyacset
 
 router = APIRouter()
@@ -62,11 +62,7 @@ def link_annotation_to_pyacset_and_paper_info(pyacset_str: str, annotations_str:
 
 
 @router.post("/profile_matrix_data", tags=["Paper-2-annotated-vars"])
-async def link_dataset_columns_to_dkg_info(gpt_key: str, csv_file: UploadFile = File(...),
-                                           doc_file: UploadFile = File(...), smart: Optional[bool] = False):
-    """
-           Smart run provides better results but may result in slow response times as a consequence of extra GPT calls.
-    """
+async def profile_matrix_data(gpt_key: str, csv_file: UploadFile = File(...), doc_file: UploadFile = File(...)):
     csv_string = await csv_file.read()
     csv_str = csv_string.decode()
 
@@ -77,7 +73,7 @@ async def link_dataset_columns_to_dkg_info(gpt_key: str, csv_file: UploadFile = 
     if dataset_type != 'matrix':
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Invalid CSV file; data type does not seem to be a matrix.")
 
-    s, success = await matrix_dkg(data=csv_str, doc=doc, dataset_name=csv_file.filename, doc_name=doc_file.filename, gpt_key=gpt_key, smart=smart)
+    s, success = await profile_matrix(data=csv_str, doc=doc, dataset_name=csv_file.filename, doc_name=doc_file.filename, gpt_key=gpt_key, smart=smart)
 
     if not success:
         return JSONResponse(status_code=status.HTTP_401_UNAUTHORIZED, content=s)

--- a/api/routers/cards.py
+++ b/api/routers/cards.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 sys.path.append(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 )
-from src.connect import construct_data_card, dataset_header_document_dkg, construct_model_card, matrix_dkg, get_dataset_type
+from src.connect import construct_data_card, dataset_header_document_dkg, construct_model_card, profile_matrix, get_dataset_type
 
 router = APIRouter()
 
@@ -40,7 +40,7 @@ async def get_data_card(gpt_key: str, csv_file: UploadFile = File(...), doc_file
         profiler = dataset_header_document_dkg
     elif data_type == 'matrix':
         schema = None
-        profiler = matrix_dkg
+        profiler = profile_matrix
     else:
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Invalid CSV file; could not determine data type")
 

--- a/api/routers/cards.py
+++ b/api/routers/cards.py
@@ -9,12 +9,12 @@ from fastapi.responses import JSONResponse
 sys.path.append(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 )
-from src.connect import construct_data_card, dataset_header_document_dkg, construct_model_card
+from src.connect import construct_data_card, dataset_header_document_dkg, construct_model_card, matrix_dkg, get_dataset_type
 
 router = APIRouter()
 
-@router.post("/get_data_card", tags=["Data-and-model-cards"])
 
+@router.post("/get_data_card", tags=["Data-and-model-cards"])
 async def get_data_card(gpt_key: str, csv_file: UploadFile = File(...), doc_file: UploadFile = File(...), smart: Optional[bool] = False):
     """
            Smart run provides better results but may result in slow response times as a consequence of extra GPT calls.
@@ -31,23 +31,22 @@ async def get_data_card(gpt_key: str, csv_file: UploadFile = File(...), doc_file
     if len(doc) == 0:
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Empty document file")
 
-    schema = csv.split('\n')[0].strip()
-    cols = [s.strip() for s in schema.split(',')]
-    # check if cols contains any entries that are entirely numeric, including both ints and floats
-    def is_numeric(s):
-        try:
-            float(s)
-            return True
-        except ValueError:
-            return False
-    if any([is_numeric(s) for s in cols]):
-        schema = ','.join([str(i) for i in range(len(cols))])
-
-
+    data_type = get_dataset_type(csv)
+    if data_type == 'header-0':
+        schema = csv.split('\n')[0].strip()
+        profiler = dataset_header_document_dkg
+    elif data_type == 'no-header':
+        schema = None
+        profiler = dataset_header_document_dkg
+    elif data_type == 'matrix':
+        schema = None
+        profiler = matrix_dkg
+    else:
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Invalid CSV file; could not determine data type")
 
     calls = [
-        construct_data_card(schema=schema, data_doc=doc, dataset_name=csv_file.filename, doc_name=doc_file.filename, gpt_key=gpt_key),
-        dataset_header_document_dkg(data=csv, doc=doc, dataset_name=csv_file.filename, doc_name=doc_file.filename, gpt_key=gpt_key, smart=smart)
+        construct_data_card(data_doc=doc, dataset_name=csv_file.filename, doc_name=doc_file.filename, dataset_type=data_type, gpt_key=gpt_key),
+        profiler(data=csv, doc=doc, dataset_name=csv_file.filename, doc_name=doc_file.filename, gpt_key=gpt_key, smart=smart)
     ]
 
     try:
@@ -63,13 +62,35 @@ async def get_data_card(gpt_key: str, csv_file: UploadFile = File(...), doc_file
             return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=s)
 
     data_card = ast.literal_eval(results[0][0])
-    data_card['SCHEMA'] = [s.strip() for s in schema.split(',')]
-    # get a random sample of a row from the csv
-    data_card['EXAMPLES'] = {k.strip(): v for k, v in zip(schema.split(','), random.sample(csv.split('\n')[1:], 1)[0].split(','))}
     data_profiling = ast.literal_eval(results[1][0])
     if 'DATA_PROFILING_RESULT' in data_card:
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content='DATA_PROFILING_RESULT cannot be a requested field in the data card.')
-    data_card['DATA_PROFILING_RESULT'] = data_profiling
+
+    if data_type == 'header-0':
+        data_card['SCHEMA'] = [s.strip() for s in schema.split(',')]
+        # get a random sample of a row from the csv
+        data_card['EXAMPLES'] = {k.strip(): v for k, v in zip(schema.split(','), random.sample(csv.split('\n')[1:], 1)[0].split(','))}
+        data_card['DATA_PROFILING_RESULT'] = data_profiling
+        data_card['EXAMPLES'] = {k.strip(): v for k, v in zip(schema.split(','), random.sample(csv.split('\n')[1:], 1)[0].split(','))}
+    elif data_type == 'no-header':
+        if 'SCHEMA' not in data_card:
+            return JSONResponse(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content='SCHEMA not found in data card')
+        schema = [s.strip() for s in data_card['SCHEMA'].split(',')]
+        schema = [s[1:] if s.startswith('[') else s for s in schema]
+        schema = [s[:-1] if s.endswith(']') else s for s in schema]
+        aligned_data_profiling = {}
+        for k, v in data_profiling.items():
+            k = int(k)
+            k = schema[k]
+            aligned_data_profiling[k] = v
+        data_card['DATA_PROFILING_RESULT'] = aligned_data_profiling
+        data_card['EXAMPLES'] = {k.strip(): v for k, v in zip(schema.split(','), random.sample(csv.split('\n')[1:], 1)[0].split(','))}
+    elif data_type == 'matrix':
+        data_card['DATA_PROFILING_RESULT'] = data_profiling
+        data_card['EXAMPLES'] = random.sample(csv.split('\n'), 1)[0].split(',')
+    else:
+        raise Exception('Invalid data type')
+
 
     return data_card
 

--- a/src/connect.py
+++ b/src/connect.py
@@ -397,7 +397,7 @@ def sort_dkg(ranking, json_obj):
     return sorted_json
 
 
-async def matrix_dkg(data, doc, dataset_name, doc_name, gpt_key='', smart=False):
+async def profile_matrix(data, doc, dataset_name, doc_name, gpt_key='', smart=False):
     """
     Grounding a matrix of data to DKG terms
     """

--- a/src/connect.py
+++ b/src/connect.py
@@ -621,7 +621,7 @@ async def construct_data_card(data_doc, dataset_name, doc_name, dataset_type, gp
             fields.append(("SCHEMA", "The dataset schema, as a comma-separated list of column names."))
         elif dataset_type == 'matrix':
             # instead of a schema, want to ask GPT to explain what a given (row, column) cell means
-            fields.append(("CELL_FORMAT", "A brief description of what a given cell in the matrix represents (i.e. a row/column pair)."))
+            fields.append(("CELL_INTERPRETATION", "A brief description of what a given cell in the matrix represents (i.e. how to interpret the value at a given a row/column pair)."))
 
     prompt = get_data_card_prompt(fields, data_doc, dataset_name, doc_name)
     match = get_gpt4_match(prompt, gpt_key, model=model)

--- a/src/prompts/data_card_prompt.txt
+++ b/src/prompts/data_card_prompt.txt
@@ -1,17 +1,11 @@
-I have a textual description of the contents of a dataset, along with the schema of the dataset.
-The dataset is called `[DATASET_NAME]`. The textual description was taken from a file called `[DOC_NAME]`.
+I have a textual description of the contents of a dataset called `[DATASET_NAME]`.
+The textual description was taken from a file called `[DOC_NAME]`.
 
 I need to extract some metadata about this dataset from these inputs.
 The metadata to be extracted is as follows:
 ```txt
 [FIELDS]
 ```
-
-The dataset schema is as follows:
-```csv
-[SCHEMA]
-```
-
 The textual description is as follows:
 ```txt
 [DOC]


### PR DESCRIPTION
This PR adds a first stab at supporting
- Tabular data without a header row. In this case, we ask GPT to provide the schema based on the documentation. **Warning: this code path is poorly tested** (but does not come up in the evaluation, as far as I know).
- Non-tabular matrix data. In this case, the data profiling simply yields matrix-wide statistics (`DATA_PROFILING_RESULTS->matrix_stats`); and instead of a schema, we ask GPT to explain what the interpretation of each cell is (how to interpret the value of a given row/matrix pair); this is given in the response as `CELL_INTERPRETATION`.

Summary of API changes:
- Added standalone `annotations/profile_matrix_data` endpoint (don't think anyone will use it, just for completeness)
- `cards/get_data_card`:
    - Inputs: No changes
    - Outputs: when the data is a matrix, `DATA_PROFILING_RESULTS` only contains `matrix_stats`; `CELL_INTERPRETATION` is given instead of `SCHEMA`; and `EXAMPLES` is a list, rather than a dictionary as in the tabular case.
    
@mikecafarella is talking to TA4 about getting this integrated; unclear if that'll happen, but at least this way we're doing our best to support non-tabular data on our side.
