### PR TITLE
switch to new match in dataset to kg api. refactor out common path fo…

### DIFF
--- a/src/connect.py
+++ b/src/connect.py
@@ -456,6 +456,8 @@ def dataset_header_dkg(header, gpt_key=''):
     return json.dumps(col_ant), True
 
 
+from kgmatching import local_batch_get_mira_dkg_term
+
 async def dataset_header_document_dkg(data, doc, dataset_name, doc_name, gpt_key='', smart=False):
     """
     Grounding the column header to DKG terms
@@ -506,29 +508,21 @@ async def dataset_header_document_dkg(data, doc, dataset_name, doc_name, gpt_key
     col_names = [col_ant[col]["col_name"] for col in col_ant]
     col_concepts = [col_ant[col]["concept"] for col in col_ant]
 
-    # line up coroutines
-    ops = [abatch_get_mira_dkg_term(col_names, ['id', 'name', 'type'], True),
-           abatch_get_mira_dkg_term(col_concepts, ['id', 'name', 'type'], True),
-           ]
-    # let them all finish
-    name_results, concept_results = await asyncio.gather(*ops)
+    terms = [ f'{col_name}: {col_concept}' for (col_name, col_concept) in zip(col_names, col_concepts) ]
+    matches = local_batch_get_mira_dkg_term(terms)
+    # # line up coroutines
+    # ops = [abatch_get_mira_dkg_term(col_names, ['id', 'name', 'type'], True),
+    #        abatch_get_mira_dkg_term(col_concepts, ['id', 'name', 'type'], True),
+    #        ]
+    # # let them all finish
+    # name_results, concept_results = await asyncio.gather(*ops)
 
-    for col, name_res, concept_res in zip(col_names, name_results, concept_results):
-        seen = set()
-        results = []
-        for res in (concept_res, name_res):  # TODO check if this is the right order
-            for r in res:
-                if not r:
-                    break
-                if not r[0] in seen:
-                    results.append(r)
-                    seen.add(r[0])
-
-        col_ant[col]["dkg_groundings"] = results
-        if results and smart:
+    for col, match in zip(col_names, matches):
+        col_ant[col]["dkg_groundings"] = match
+        if smart:
             target = copy.deepcopy(col_ant[col])
             del target["dkg_groundings"]
-            res=rank_dkg_terms(target, results, gpt_key)[0]
+            res=rank_dkg_terms(target, match, gpt_key)[0]
             col_ant[col]["dkg_groundings"] = res
             print(f"Smart grounding for {col}: {res}")
 

--- a/src/kgmatching.py
+++ b/src/kgmatching.py
@@ -53,17 +53,14 @@ import os
 g_kgpath = os.path.dirname(__file__) + '/../epi_2023-07-07_nodes.tsv'
 g_retriever = build_node_retriever(g_kgpath, limit=4)
 
-def local_batch_get_mira_dkg_term(term_dict):
+from typing import List
+def local_batch_get_mira_dkg_term(term_list : List[str]) -> List[dict]:
     batch_ans = []
-    for (term_name,term_desc) in term_dict.items():
-        gpt_desc = term_desc['description'][0]
-        # x = term_name + ':' + term_desc
-        docs = g_retriever.get_relevant_documents(term_name +':' + gpt_desc)
+    for term in term_list:
+        docs = g_retriever.get_relevant_documents(term)
         ansdocs = []
         for doc in docs:
             meta = {}
-            meta['llm_output_name']=term_name
-            meta['llm_output_desc']=gpt_desc
             meta.update(doc.metadata)
             ansdocs.append(meta)
 

--- a/src/text_search.py
+++ b/src/text_search.py
@@ -94,10 +94,17 @@ async def avars_to_json(var_dict: dict) -> str:
     is_first = True
     id = 0
 
-    batch_var_ground0 = local_batch_get_mira_dkg_term(var_dict)
+    term_list = []
+    meta_list = []
+    for (term_name,term_desc) in var_dict.items():
+        gpt_desc = term_desc['description'][0]
+        term_list.append(term_name +':' + gpt_desc)
+        meta_list.append({'llm_output_name':term_name,
+                         'llm_output_desc':gpt_desc})
+    
+    batch_var_ground0 = local_batch_get_mira_dkg_term(term_list)
     pretty_var0 = json.dumps(batch_var_ground0, indent=2)
     print(f'batch_var_ground\n{pretty_var0}')
-
 
     # batch_var_ground = await abatch_get_mira_dkg_term(var_dict.keys(), ['id', 'name'])
     # pretty_var = json.dumps(batch_var_ground, indent=2)


### PR DESCRIPTION
Tested /annotation/link_dataset_col_to_dkg on abm.

Results make more sense:

eg. before:
{
  "dates": {
    "col_name": "dates",
    "concept": "Date of data collection",
    "unit": "Date",
    "description": "The date when the data was collected.",
    "dkg_groundings": [
      [
        "hp:0001147",
        "Retinal exudate",
        "class"
      ],
      [
        "hp:0030496",
        "Macular exudate",
        "class

after:
{
  "dates": {
    "col_name": "dates",
    "concept": "Date of data collection",
    "unit": "Date",
    "description": "The date when the data was collected.",
    "dkg_groundings": [
      {
        "name": "date",
        "synonyms": "",
        "id": "oboinowl:date",
        "description": "Date.",
        "type": "property"
      },
      {
        "name": "Date",
        "synonyms": "",
        "id": "dc:date",
        "description": "",
        "type": "property"
      },

