### PR TITLE
More robust CSV handling

### DIFF
--- a/api/routers/annotation.py
+++ b/api/routers/annotation.py
@@ -66,7 +66,7 @@ async def profile_matrix_data(gpt_key: str, csv_file: UploadFile = File(...), do
 
     csv_string = await csv_file.read()
     csv_str = csv_string.decode()
-    csv_reader = csv.reader(io.StringIO(csv_str), dialect=csv.Sniffer().sniff(csv_str.splitlines()[0]))
+    csv_reader = csv.reader(io.StringIO(csv_str), dialect=csv.Sniffer().sniff(csv_str.splitlines()[-1]))
 
     doc = await doc_file.read()
     doc = doc.decode()
@@ -93,7 +93,7 @@ async def link_dataset_columns_to_dkg_info(gpt_key: str, csv_file: UploadFile = 
     """
     csv_string = await csv_file.read()
     csv_str = csv_string.decode()
-    csv_reader = csv.reader(io.StringIO(csv_str), dialect=csv.Sniffer().sniff(csv_str.splitlines()[0]))
+    csv_reader = csv.reader(io.StringIO(csv_str), dialect=csv.Sniffer().sniff(csv_str.splitlines()[-1]))
 
     doc = await doc_file.read()
     doc = doc.decode()

--- a/api/routers/cards.py
+++ b/api/routers/cards.py
@@ -31,7 +31,7 @@ async def get_data_card(gpt_key: str, csv_file: UploadFile = File(...), doc_file
     if len(doc) == 0:
         return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content="Empty document file")
 
-    csv_reader = csv.reader(io.StringIO(_csv), dialect=csv.Sniffer().sniff(_csv.splitlines()[0]))
+    csv_reader = csv.reader(io.StringIO(_csv), dialect=csv.Sniffer().sniff(_csv.splitlines()[-1]))
 
     header = next(csv_reader)  # can determine type from the header row
     data_type = get_dataset_type(header)

--- a/src/gen_petri.py
+++ b/src/gen_petri.py
@@ -27,7 +27,7 @@ def get_arcs(text, gpt_key):
         prompt = get_petri_arcs_prompt(text)
         match = get_gpt_match(prompt, gpt_key, "text-davinci-003")
         #print(match)
-        lines = match.split("\n")
+        lines = match.splitlines()
         transitions = []
         for line in lines:
             words = [w.rstrip() for w in line.split("->")]

--- a/src/text_search.py
+++ b/src/text_search.py
@@ -28,7 +28,7 @@ def text_var_search(text, gpt_key):
 def vars_dedup(text:str) -> dict:
     var_dict = {}
 
-    lines = text.split("\n")
+    lines = text.splitlines()
 
     # Build dictionary, deduplicating along the way
     for line in lines:


### PR DESCRIPTION
- Use Python's CSV library to parse the inputs rather than DYI. Should handle different dialects (e.g. tab-separated, comma-separated); cells with values that contain commas (e.g. "123,456"); and non-Unix line endings.
- Gave up on the tabular-data-without-a-header-row code path; returning 400 if needed. This never comes up in the scenarios, and just isn't really well-specified; I think we just wanted to support it before we decided to go all-in on a separate path for matrix data