### PR TITLE
Fix: handle poorly formatted column names

### DIFF
--- a/src/connect.py
+++ b/src/connect.py
@@ -484,22 +484,21 @@ async def dataset_header_document_dkg(data, doc, dataset_name, doc_name, gpt_key
         match = match[0]
     else:
         match = match[1]
-    for res in match.splitlines():
-        res = res.strip()
-        if not res:
-            continue
-        attrs = [x.strip() for x in res.split("|")]
-        if len(attrs) != 4:
-            continue
-        col = attrs[0]
+    results = [s.strip() for s in match.splitlines()]
+    results = [s for s in results if s]
+    results = [[x.strip() for x in s.split("|")] for s in results]
+    results = [x for x in results if len(x) == 4]
+    if len(results) != len(header):
+        return f"Got different number of results ({len(results)}) than columns ({len(header)})", False
+
+    for res, col in zip(results, header):
         col_ant[col] = {}
-        col_ant[col]["col_name"] = attrs[0]
-        col_ant[col]["concept"] = attrs[1]
-        col_ant[col]["unit"] = attrs[2]
-        col_ant[col]["description"] = attrs[3]
+        col_ant[col]["col_name"] = res[0]
+        col_ant[col]["concept"] = res[1]
+        col_ant[col]["unit"] = res[2]
+        col_ant[col]["description"] = res[3]
 
-
-    col_names = [col_ant[col]["col_name"] for col in col_ant]
+    col_names = list(col_ant.keys())
     col_concepts = [col_ant[col]["concept"] for col in col_ant]
 
     terms = [ f'{col_name}: {col_concept}' for (col_name, col_concept) in zip(col_names, col_concepts) ]

--- a/src/prompts/dataset_profiling_prompt.txt
+++ b/src/prompts/dataset_profiling_prompt.txt
@@ -31,6 +31,7 @@ Please give your answer exactly in the following format:
 ...
 ```
 Make sure to replace `<column name>`, `<concept>`, `<unit>`, and `<description>` with the correct values.
+List the columns in the same order as they appear in the dataset schema, with exactly one line per column.
 Also make sure to format the answer exactly as shown above, with the pipe character `|` separating the four values and a ```-block surrounding the answer.
 Finally, do not merge multiple columns into one line, and do not split any one column into multiple lines.
 


### PR DESCRIPTION
This is a workaround for the fact that GPT tends to strip "formatting characters" like \n etc from column names (which COSMOS sometimes gives us).

As discussed on slack:
- Ask GPT to give data profiling results in the order that columns appear in the schema
- Assume it successfully does so
- zip header with results